### PR TITLE
Corrected link to Json-ld section

### DIFF
--- a/howto/index.html
+++ b/howto/index.html
@@ -26,7 +26,7 @@
 					<ul class="navbar-nav ml-auto">
 						<li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#Csv">.csv</a></li>
 						<li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#Dump">rdf Dump</a></li>
-						<li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#jsonld">Json-ld</a></li>
+						<li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" href="#Jsonld">Json-ld</a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
The link (https://ontology.uis-speleo.org/howto/#jsonld) did not work as the capitalisation needs to be the same for the link source and destination.